### PR TITLE
add Config table to client script

### DIFF
--- a/client/client.lua
+++ b/client/client.lua
@@ -1,3 +1,5 @@
+Config = {}
+
 --[[To add clothes, copy the hash, paste it at the end of the list and add range in slider(_f means women Only MP components work)--]]
 
 local lista_kapelusze = {} --hat


### PR DESCRIPTION
Map blips weren't appearing for me and restarting the script caused this error:
https://i.imgur.com/6KAE8k9.png

Added config table to the client script which resolves the error